### PR TITLE
chore: use ltex-ls for markdown lsp again

### DIFF
--- a/dot_config/helix/private_languages.toml
+++ b/dot_config/helix/private_languages.toml
@@ -1,0 +1,3 @@
+[[language]]
+name = "markdown"
+language-server = { command = "ltex-ls" }


### PR DESCRIPTION
I favor the spell-check to the (admittedly nifty) Marksman experience.

I can't wait until helix supports multiple LSPs!

Ticket: 0